### PR TITLE
SISWSE-28: add 'ANONYMOUS_LOGIN_EXPIRATION' setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.1.0]
+
+### Added
+- settings.ANONYMOUS_LOGIN_EXPIRATION to allow expiration of AnonymousLogin
+
+## [1.0.0]
 
 ### Added
 - Initial setup

--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ OR
 2. Directly add the `AnonymousLoginAuthentication` and `IsAuthenticated` to your ViewSet's `authentication_classes` and
    `permission_classes` as implemented in the [AnonymousLoginAuthenticationModelViewSet](drf_anonymous_login/views.py).
 
+#### Configure token expiration
+The tokens will not expire by default (expiration_datetime remains `None`). You can  configure the 
+`ANONYMOUS_LOGIN_EXPIRATION` in your application's `settings.py` to define a default expiration in minutes, e.g.
+to have any token only valid for 15 minutes, use:
+```python
+# settings.py
+
+...
+ANONYMOUS_LOGIN_EXPIRATION=15
+
+```
+
 ## Unit Tests
 
 See folder [tests/](tests/). The provided tests cover these criteria:

--- a/drf_anonymous_login/models.py
+++ b/drf_anonymous_login/models.py
@@ -1,7 +1,10 @@
 import binascii
 import os
+from datetime import timedelta
 
+from django.conf import settings
 from django.db import models
+from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 
@@ -16,8 +19,17 @@ class AnonymousLogin(models.Model):
     def save(self, *args, **kwargs):
         if not self.token:
             self.token = self.generate_token()
+
+        if not self.expiration_datetime:
+            self.expiration_datetime = self.set_default_expiration_datetime()
         return super().save(*args, **kwargs)
 
     @staticmethod
     def generate_token():
         return binascii.hexlify(os.urandom(32)).decode()
+
+    @staticmethod
+    def set_default_expiration_datetime():
+        default_expiration = getattr(settings, "ANONYMOUS_LOGIN_EXPIRATION", None)
+        if default_expiration:
+            return timezone.now() + timedelta(minutes=default_expiration)

--- a/tests/testapp/tests/test_api.py
+++ b/tests/testapp/tests/test_api.py
@@ -21,6 +21,19 @@ class TestApi(TestCase):
     def login_header(self):
         return {AUTH_HEADER: "{} {}".format(AUTH_KEYWORD, self.anonymous_login.token)}
 
+    def test_no_default_expiration_datetime(self):
+        self.assertIsNone(self.anonymous_login.expiration_datetime)
+
+    def test_default_expiration_datetime(self):
+        with self.settings(ANONYMOUS_LOGIN_EXPIRATION=15):
+            today = timezone.now()
+            self.anonymous_login = AnonymousLogin.objects.create(request_data={})
+            self.assertIsNotNone(self.anonymous_login.expiration_datetime)
+            self.assertGreater(self.anonymous_login.expiration_datetime, today)
+            self.assertLess(
+                self.anonymous_login.expiration_datetime, today + timedelta(minutes=16)
+            )
+
     def test_no_login(self):
         """
         Assert that token is required only for protected viewsets (with AnonymousLoginAuthenticationModelViewSet),


### PR DESCRIPTION
Allow the configuration of a default duration for `AnonymousLogin.expiration_datetime`. The update allows configuration of `settings.ANONYMOUS_LOGIN_EXPIRATION` in minutes.